### PR TITLE
Added a 'All the Blogs' button to redirect to 'all blogs' section

### DIFF
--- a/src/components/posts/Posts.css
+++ b/src/components/posts/Posts.css
@@ -4,3 +4,31 @@
     flex-wrap: wrap;
     justify-content: center;
 }
+a:hover{ 
+    text-decoration: none;
+}
+.AllBlog{
+    display: flex;
+    justify-content:center;
+    align-items:center;
+    margin: 10px 0 0;
+}
+.Blog-But{
+    display: flex;
+    justify-content:center;
+    align-items:center;
+    border-radius: 15px;
+    font-weight:bolder;
+    font-size: 20px;
+    background-color: white;
+}
+.Blog-But:active{
+    position: relative;
+    top:4px;
+    box-shadow: none;
+}
+.Arrow{
+    font-size: 30px;
+    margin: 4px 0 0;
+    font-weight:bolder;
+}

--- a/src/components/posts/Posts.jsx
+++ b/src/components/posts/Posts.jsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import axios from "axios";
 import "./Posts.css";
 import { Puff } from "react-loader-spinner";
-
+import { Link } from 'react-router-dom';
 const Posts = () => {
   const { search } = useLocation();
   const [posts, setPosts] = useState([]);
@@ -23,15 +23,27 @@ const Posts = () => {
     fetchPosts();
   }, [search]);
   return (
-    <div className="posts">
-      {exec ? (
-        posts.map((post) => <Post key={post._id} post={post} />)
-      ) : (
-        <div className="puffLoader">
-          <Puff color="#2D81F7" height={100} width={100} className="loader" />
-        </div>
-      )}
-    </div>
+    <div>
+      <div className="posts">
+        {exec ? (
+          posts.map((post) => <Post key={post._id} post={post} />)
+        ) : (
+          <div className="puffLoader">
+            <Puff color="#2D81F7" height={100} width={100} className="loader" />
+          </div>
+        )}
+      </div>
+      <div>
+        {/* http://localhost:3000/blogs */}
+        {window.location.href !== "https://www.algoderscommunity.tech/blogs" ? (
+          <div className="AllBlog">
+            <Link to="/blogs"><button className="Blog-But"><span className="Arrow">&#11176;</span>All the Blogs</button></Link>
+          </div>
+        ) : (
+          <div></div>
+        )}
+      </div>
+    </div >
   );
 };
 


### PR DESCRIPTION
Describe the bug
There's no 'ALL' tag(or category) on the blogs page header, through which the user can see all different types of blogs together. It's just on the initial page reload where all blogs are seen together, but after choosing any category, we cannot go back to ALL blogs category.

To Reproduce
Steps to reproduce the behavior:

1. Go to [Blogs](https://www.algoderscommunity.tech/blogs)
2. See error

Expected behavior: 'Solved'
'All the Blogs' button  is added to redirect the user 'all blogs' section. The button only appears when the user is on any other specific category.

Video

https://user-images.githubusercontent.com/84590758/156642103-1ce5c9c2-f514-44dc-8bca-2be1ccc57d76.mp4

