### PR TITLE
Fix Image Issue on About Us Page

### DIFF
--- a/src/components/about/About.js
+++ b/src/components/about/About.js
@@ -39,7 +39,7 @@ function About() {
             <img
               src="https://bootstrapious.com/i/snippets/sn-about/illus.png"
               alt=""
-              className="img-fluid "
+              className="img-fluid"
             />
           </div>
         </div>

--- a/src/components/cards/Card.js
+++ b/src/components/cards/Card.js
@@ -1,30 +1,26 @@
-import React from 'react'
-import './card.css';
-import What from '../../assets/collaborate1.png'
+import React from "react";
+import "./card.css";
+import What from "../../assets/collaborate1.png";
 function Card(props) {
   return (
-      <>
-      <div className="card"> 
-    
-    <div className="image">
-        {/* "https://th.bing.com/th/id/OIP.YRXVJb9uDspJlnhTjxdArAHaHa?pid=ImgDet&rs=1" */}
-        <img src={props.image}></img>
-    </div>
-    <div className="text">
-        <div className="heading">
-            {props.heading}</div>
-        <div className="body">
-        {/* normal : It is the normal font-weight.  It is the same as 400, the default numeric-value for boldness.
+    <>
+      <div className="card">
+        <div className="image">
+          {/* "https://th.bing.com/th/id/OIP.YRXVJb9uDspJlnhTjxdArAHaHa?pid=ImgDet&rs=1" */}
+          <img className={"card-img"} src={props.image}></img>
+        </div>
+        <div className="text">
+          <div className="heading">{props.heading}</div>
+          <div className="body">
+            {/* normal : It is the normal font-weight.  It is the same as 400, the default numeric-value for boldness.
 bold : It is the bold font-weight. It is the same as 700.
 bolder : It sets the font-weight bolder than the  */}
-{props.body}
+            {props.body}
+          </div>
         </div>
-    </div>
-</div>
-
-      </>
-    
-  )
+      </div>
+    </>
+  );
 }
 
-export default Card
+export default Card;

--- a/src/components/cards/card.css
+++ b/src/components/cards/card.css
@@ -50,3 +50,8 @@
   font-weight: 100;
   font-size: 17px;
 }
+
+.card-img {
+  width: 9em;
+  padding-right: 2em;
+}


### PR DESCRIPTION
Fix #55

Fixed the image issue on the about us page which was caused due to my previous merged PR. You can now check out the about us page as well as the homepage. It happened due to the lack of hyperlinks in Navbar as well as on Footer. Without hyperlinks, most users don't know about these separate pages existing on the site.

Screenshot -

1) Homepage Screenshot

![image](https://user-images.githubusercontent.com/59647563/162907282-4d413fae-8e41-42c9-ad44-99ac47910989.png)

2) About Us Page Screenshot

![image](https://user-images.githubusercontent.com/59647563/162907336-42e0ac49-b7a9-42ba-b0d2-d2cd1fdead0f.png)
